### PR TITLE
Fix display font initialization bug

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -98,7 +98,7 @@ void Display::setup() {
       _height[0] = 4;
       _height[1] = 4;
       _fontSize[0] = FontSize::FONT_1;
-      _fontSize[0] = FontSize::FONT_1;
+      _fontSize[1] = FontSize::FONT_1;
 
       _displayLCD[0]->begin(_width[0], _height[0]);
       _displayLCD[1]->begin(_width[1], _height[1]);


### PR DESCRIPTION
## Summary
- correct second LCD font initialization to use the right array index

## Testing
- `pip install platformio` *(fails: Could not find a version due to network restrictions)*